### PR TITLE
Fixing typo

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -82,7 +82,7 @@ exports.get = function (key, callback) {
   }
   else if (typeof value === 'object') {
     cliConfig.app.log.data(key.yellow);
-    app.inspect.putObject(value);
+    cliConfig.app.inspect.putObject(value);
     return callback();
   }
     


### PR DESCRIPTION
Fixing typo in `lib/commands.js`, `app` object is accessible from `cliConfig.app`
